### PR TITLE
Changed apostrophe in html to escape character

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -28,7 +28,7 @@
     </header>
 
     <div id=aboutUsBlurb>
-      [name of group] is composed of a team of four CodeFellows 201 students, and this web app is our final project. We're based in Portland, OR.
+      [name of group] is composed of a team of four CodeFellows 201 students, and this web app is our final project. We&#96;re based in Portland, OR.
     </div>
 
     <div class=aboutUs>


### PR DESCRIPTION
In aboutus.html there was an apostrophe in the marked up text that was freaking me out...

I changed it to the escape character for an apostrophe.
